### PR TITLE
docs: link to the actual repository

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -9,7 +9,7 @@
     "metalcupcake5"
   ],
   "contact": {
-    "sources": "https://github.com/metalcupcake5"
+    "sources": "https://github.com/metalcupcake5/JustEnoughUpdates"
   },
 
   "license": "GNU AGPLv3",


### PR DESCRIPTION
This PR changes the `sources` contact link to the source code repository.