### PR TITLE
fix crash

### DIFF
--- a/src/main/java/io/github/metalcupcake5/JustEnoughUpdates/config/ConfigManager.java
+++ b/src/main/java/io/github/metalcupcake5/JustEnoughUpdates/config/ConfigManager.java
@@ -25,7 +25,7 @@ public class ConfigManager {
     public static boolean cultReminder = false;
     public static String cultReminderTime = "";
 
-    public static final String[] cultReminderTimeList = new String[]{"12:00pm", "11:00pm", "11:30pm"};
+    public static final String[] cultReminderTimeList = new String[]{"0:0", "23:00", "23:30"};
 
     public static final Path CONFIG = FabricLoader.getInstance().getConfigDir().resolve("justenoughupdates.json");
 

--- a/src/main/java/io/github/metalcupcake5/JustEnoughUpdates/events/TickEvent.java
+++ b/src/main/java/io/github/metalcupcake5/JustEnoughUpdates/events/TickEvent.java
@@ -3,6 +3,7 @@ package io.github.metalcupcake5.JustEnoughUpdates.events;
 import io.github.metalcupcake5.JustEnoughUpdates.config.ConfigManager;
 import io.github.metalcupcake5.JustEnoughUpdates.utils.ChatUtils;
 import io.github.metalcupcake5.JustEnoughUpdates.utils.SkyblockChecker;
+import io.github.metalcupcake5.JustEnoughUpdates.utils.SkyblockTime;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.sound.SoundEvents;
 
@@ -18,27 +19,26 @@ public class TickEvent {
             if (client.world != null && !client.isInSingleplayer())
                 SkyblockChecker.check();
             TICKS = 0;
-            //System.out.println(SkyblockTime.getCurrentMonth() + " " + SkyblockTime.getCurrentDay() + " " + SkyblockTime.getCurrentTime());
             if(SkyblockChecker.inDwarvenMines) {
                 if (ConfigManager.skymallNotifEnabled) {
-                    String time = "12:00am";
-                    if (SkyblockChecker.time.equals(time) && !skymall) {
+                    String time = "0:0";
+                    if (SkyblockTime.getCurrentTime().equals(time) && !skymall) {
                         ChatUtils.sendClientMessage("skymall changed");
                         assert client.player != null;
                         client.player.playSound(SoundEvents.BLOCK_NOTE_BLOCK_BELL, 100, 1);
                         skymall = true;
                     }
-                    if (!SkyblockChecker.time.equals(time) && skymall) {
+                    if (!SkyblockTime.getCurrentTime().equals(time) && skymall) {
                         skymall = false;
                     }
                 }
 
                 if(ConfigManager.cultReminder) {
-                    if (!cult && SkyblockChecker.time.equals(ConfigManager.cultReminderTime) && (SkyblockChecker.day + 1) % 7 == 0) {
+                    if (!cult && SkyblockTime.getCurrentTime().equals(ConfigManager.cultReminderTime) && (SkyblockTime.getCurrentDay() + 1) % 7 == 0) {
                         ChatUtils.sendClientMessage("cult is soon");
                         cult = true;
                     }
-                    if (!((SkyblockChecker.day + 1) % 7 == 0) && cult && !SkyblockChecker.time.equals(ConfigManager.cultReminderTime)) {
+                    if (!((SkyblockTime.getCurrentDay() + 1) % 7 == 0) && cult && !SkyblockTime.getCurrentTime().equals(ConfigManager.cultReminderTime)) {
                         cult = false;
                     }
                 }

--- a/src/main/java/io/github/metalcupcake5/JustEnoughUpdates/events/TickEvent.java
+++ b/src/main/java/io/github/metalcupcake5/JustEnoughUpdates/events/TickEvent.java
@@ -18,7 +18,7 @@ public class TickEvent {
             if (client.world != null && !client.isInSingleplayer())
                 SkyblockChecker.check();
             TICKS = 0;
-            //ChatUtils.sendClientMessage(Formatting.BOLD + "hi");
+            //System.out.println(SkyblockTime.getCurrentMonth() + " " + SkyblockTime.getCurrentDay() + " " + SkyblockTime.getCurrentTime());
             if(SkyblockChecker.inDwarvenMines) {
                 if (ConfigManager.skymallNotifEnabled) {
                     String time = "12:00am";

--- a/src/main/java/io/github/metalcupcake5/JustEnoughUpdates/utils/SkyblockChecker.java
+++ b/src/main/java/io/github/metalcupcake5/JustEnoughUpdates/utils/SkyblockChecker.java
@@ -19,9 +19,6 @@ public class SkyblockChecker {
     public static boolean inSkyblock = false;
     public static boolean inDwarvenMines = false;
     public static String location = "";
-    public static String time = "";
-    public static String season = "";
-    public static int day = 1;
 
     public static void check() {
         List<String> sidebar = getSidebar();
@@ -31,19 +28,12 @@ public class SkyblockChecker {
             inSkyblock = sidebar.get(0).contains("SKYBLOCK");
 
             if(inSkyblock) {
-                ArrayList<String> timeArray = new ArrayList<>(Arrays.asList(sidebar.get(3).split(" ")));
-                if (!timeArray.isEmpty()) time = timeArray.get(1);
 
                 ArrayList<String> locationArray = new ArrayList<>(Arrays.asList(sidebar.get(4).split(" ")));
                 locationArray.remove(0);
                 locationArray.remove(0);
                 location = String.join(" ", locationArray);
                 inDwarvenMines = isInDwarvenMines(location);
-
-                ArrayList<String> dateArray = new ArrayList<>(Arrays.asList(sidebar.get(2).split(" ")));
-                season = dateArray.get(1);
-                String[] splitDate = sidebar.get(2).split("([A-z])\\w+");
-                day = Integer.parseInt(splitDate[splitDate.length - 1].trim());
             }
         } else {
             inSkyblock = false;

--- a/src/main/java/io/github/metalcupcake5/JustEnoughUpdates/utils/SkyblockTime.java
+++ b/src/main/java/io/github/metalcupcake5/JustEnoughUpdates/utils/SkyblockTime.java
@@ -1,0 +1,46 @@
+package io.github.metalcupcake5.JustEnoughUpdates.utils;
+
+import java.time.Instant;
+
+public class SkyblockTime {
+
+    public static final int HOUR_S = 50;
+    public static final int DAY_S = 24 * HOUR_S;
+    public static final int MONTH_LENGTH = 31;
+    public static final int YEAR_LENGTH = 12;
+    public static final int MONTH_S = MONTH_LENGTH * DAY_S;
+    public static final int YEAR_S = YEAR_LENGTH * MONTH_S;
+    public static final int YEAR_0 = 1560275700; // in seconds
+
+    public static final String[] MONTHS = new String[]{
+        "Early Spring", "Spring", "Late Spring",
+        "Early Summer", "Summer", "Late Summer",
+        "Early Autumn", "Autumn", "Late Autumn",
+        "Early Winter", "Winter", "Late Winter"
+    };
+
+    // in 24 hour time
+    public static String getCurrentTime(){
+        double currentOffset = (Instant.now().getEpochSecond() - YEAR_0) % YEAR_S;
+        double currentMonth = Math.floor(currentOffset / MONTH_S);
+        double currentMonthOffset = (currentOffset - currentMonth * MONTH_S) % MONTH_S;
+        double currentDay = Math.floor(currentMonthOffset / DAY_S);
+        double currentDayOffset = (currentMonthOffset - currentDay * DAY_S) % DAY_S;
+        int currentHour = (int) Math.floor(currentDayOffset / HOUR_S);
+        int currentMinute = (int) Math.floor((currentDayOffset - currentHour * HOUR_S) / HOUR_S * 60);
+        return currentHour + ":" + currentMinute;
+    }
+
+    public static int getCurrentDay() {
+        double currentOffset = (Instant.now().getEpochSecond() - YEAR_0) % YEAR_S;
+        double currentMonth = Math.floor(currentOffset / MONTH_S);
+        double currentMonthOffset = (currentOffset - currentMonth * MONTH_S) % MONTH_S;
+        return (int) Math.floor(currentMonthOffset / DAY_S) + 1;
+    }
+
+    public static String getCurrentMonth() {
+        double currentOffset = (Instant.now().getEpochSecond() - YEAR_0) % YEAR_S;
+        return MONTHS[(int) Math.floor(currentOffset / MONTH_S)];
+    }
+
+}

--- a/src/main/java/io/github/metalcupcake5/JustEnoughUpdates/utils/SkyblockTime.java
+++ b/src/main/java/io/github/metalcupcake5/JustEnoughUpdates/utils/SkyblockTime.java
@@ -28,7 +28,7 @@ public class SkyblockTime {
         double currentDayOffset = (currentMonthOffset - currentDay * DAY_S) % DAY_S;
         int currentHour = (int) Math.floor(currentDayOffset / HOUR_S);
         int currentMinute = (int) Math.floor((currentDayOffset - currentHour * HOUR_S) / HOUR_S * 60);
-        return currentHour + ":" + currentMinute;
+        return currentHour + ":" + currentMinute/10*10;
     }
 
     public static int getCurrentDay() {


### PR DESCRIPTION
fixes crashing related to reading sidebar 
[example](https://cdn.discordapp.com/attachments/798149664012501032/941910134190399508/Replay_2022-02-12_05-11-49.mp4)
caused by values on sidebar shifting around, resulting in attempting to parse the wrong row