### PR TITLE
refactor: speed up time check methods

### DIFF
--- a/src/main/java/io/github/metalcupcake5/JustEnoughUpdates/JustEnoughUpdates.java
+++ b/src/main/java/io/github/metalcupcake5/JustEnoughUpdates/JustEnoughUpdates.java
@@ -4,6 +4,7 @@ import io.github.metalcupcake5.JustEnoughUpdates.config.ConfigManager;
 import io.github.metalcupcake5.JustEnoughUpdates.events.ItemTooltipEvent;
 import io.github.metalcupcake5.JustEnoughUpdates.events.TickEvent;
 import io.github.metalcupcake5.JustEnoughUpdates.utils.SkyblockChecker;
+import io.github.metalcupcake5.JustEnoughUpdates.utils.SkyblockTime;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.client.command.v1.ClientCommandManager;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
@@ -55,6 +56,8 @@ public class JustEnoughUpdates implements ModInitializer {
 		ItemTooltipCallback.EVENT.register((ItemTooltipEvent::onTooltip));
 
 		ConfigManager.loadConfig();
+
+		SkyblockTime.recalibrateTime();
 	}
 
 

--- a/src/main/java/io/github/metalcupcake5/JustEnoughUpdates/events/TickEvent.java
+++ b/src/main/java/io/github/metalcupcake5/JustEnoughUpdates/events/TickEvent.java
@@ -16,33 +16,37 @@ public class TickEvent {
 
         TICKS++;
         if (TICKS % 20 == 0) {
+            SkyblockTime.time += 1000;
             if (client.world != null && !client.isInSingleplayer())
                 SkyblockChecker.check();
-            TICKS = 0;
             if(SkyblockChecker.inDwarvenMines) {
                 if (ConfigManager.skymallNotif) {
                     String time = "0:00";
-                    if (SkyblockTime.getCurrentTime().equals(time) && !skymall) {
+                    if (SkyblockTime.getCurrentSkyblockTime().equals(time) && !skymall) {
                         ChatUtils.sendClientMessage("skymall changed");
                         assert client.player != null;
                         client.player.playSound(SoundEvents.BLOCK_NOTE_BLOCK_BELL, 100, 1);
                         skymall = true;
                     }
-                    if (!SkyblockTime.getCurrentTime().equals(time) && skymall) {
+                    if (!SkyblockTime.getCurrentSkyblockTime().equals(time) && skymall) {
                         skymall = false;
                     }
                 }
 
                 if(ConfigManager.cultReminder) {
-                    if (!cult && SkyblockTime.getCurrentTime().equals(ConfigManager.cultReminderTime)) {
+                    if (!cult && SkyblockTime.getCurrentSkyblockTime().equals(ConfigManager.cultReminderTime)) {
                         ChatUtils.sendClientMessage("cult is soon");
                         cult = true;
                     }
-                    if (!((SkyblockTime.getCurrentDay() + 1) % 7 == 0) && cult && !SkyblockTime.getCurrentTime().equals(ConfigManager.cultReminderTime)) {
+                    if (!((SkyblockTime.getCurrentDay() + 1) % 7 == 0) && cult && !SkyblockTime.getCurrentSkyblockTime().equals(ConfigManager.cultReminderTime)) {
                         cult = false;
                     }
                 }
             }
+        }
+        if (TICKS % 200 == 0){
+            SkyblockTime.recalibrateTime();
+            TICKS = 0;
         }
     }
 }

--- a/src/main/java/io/github/metalcupcake5/JustEnoughUpdates/utils/SkyblockTime.java
+++ b/src/main/java/io/github/metalcupcake5/JustEnoughUpdates/utils/SkyblockTime.java
@@ -12,6 +12,8 @@ public class SkyblockTime {
     public static final int YEAR_S = YEAR_LENGTH * MONTH_S;
     public static final int YEAR_0 = 1560275700; // in seconds
 
+    public static long time;
+
     public static final String[] MONTHS = new String[]{
         "Early Spring", "Spring", "Late Spring",
         "Early Summer", "Summer", "Late Summer",
@@ -19,9 +21,17 @@ public class SkyblockTime {
         "Early Winter", "Winter", "Late Winter"
     };
 
+    public static long getTime(){
+        return time;
+    }
+
+    public static void recalibrateTime(){
+        time = Instant.now().getEpochSecond();
+    }
+
     // in 24 hour time
-    public static String getCurrentTime(){
-        double currentOffset = (Instant.now().getEpochSecond() - YEAR_0) % YEAR_S;
+    public static String getCurrentSkyblockTime(){
+        double currentOffset = (time - YEAR_0) % YEAR_S;
         double currentMonth = Math.floor(currentOffset / MONTH_S);
         double currentMonthOffset = (currentOffset - currentMonth * MONTH_S) % MONTH_S;
         double currentDay = Math.floor(currentMonthOffset / DAY_S);
@@ -33,14 +43,14 @@ public class SkyblockTime {
     }
 
     public static int getCurrentDay() {
-        double currentOffset = (Instant.now().getEpochSecond() - YEAR_0) % YEAR_S;
+        double currentOffset = (time - YEAR_0) % YEAR_S;
         double currentMonth = Math.floor(currentOffset / MONTH_S);
         double currentMonthOffset = (currentOffset - currentMonth * MONTH_S) % MONTH_S;
         return (int) Math.floor(currentMonthOffset / DAY_S) + 1;
     }
 
     public static String getCurrentMonth() {
-        double currentOffset = (Instant.now().getEpochSecond() - YEAR_0) % YEAR_S;
+        double currentOffset = (time - YEAR_0) % YEAR_S;
         return MONTHS[(int) Math.floor(currentOffset / MONTH_S)];
     }
 


### PR DESCRIPTION
speeds up time check methods by not using `Instant.now().getEpochSecond()` every single time